### PR TITLE
Inherit config dir if SX_CONFIGURATION_DIR defined

### DIFF
--- a/lib/sx/__init__.py
+++ b/lib/sx/__init__.py
@@ -279,7 +279,11 @@ class SXConfigurationFiles:
     """
     REPORT_USER_IMPORT="sxreports"
     PLUGIN_USER_IMPORT="sxplugins"
-    CONFIGURATION_DIR = os.path.join(os.environ['HOME'],".sx")
+    try:
+        if os.environ['SX_CONFIGURATION_DIR'] is not None:
+            CONFIGURATION_DIR = os.environ['SX_CONFIGURATION_DIR']
+    except KeyError:
+        CONFIGURATION_DIR = os.path.join(os.environ['HOME'],".sx")
 
     def generateDefaultConfigurationDirectories(self):
         """


### PR DESCRIPTION
When `SX_CONFIGURATION_DIR` is defined it will take precedence. Otherwise still defaults to the standard behavior and location.